### PR TITLE
Anyone now can add global options through the messageCenterServiceProvider. This resolves #26

### DIFF
--- a/message-center.js
+++ b/message-center.js
@@ -5,9 +5,26 @@
 var MessageCenterModule = angular.module('MessageCenterModule', []);
 
 // Define a service to inject.
-MessageCenterModule.
-  service('messageCenterService', ['$rootScope', '$sce', '$timeout',
-    function ($rootScope, $sce, $timeout) {
+MessageCenterModule
+  .provider("$messageCenterService", function() {
+    var _this = this;
+    _this.options = {};
+    _this.setGlobalOptions = function(options) {
+      _this.options = options;
+    }
+    _this.getOptions = function(options) {
+      return _this.options;
+    }
+    this.$get = function() {
+      return {
+        setGlobalOptions: _this.setGlobalOptions,
+        options: _this.options,
+        getOptions: _this.getOptions
+      }
+    }
+  })
+  .service('messageCenterService', ['$rootScope', '$sce', '$timeout','$messageCenterService',
+    function ($rootScope, $sce, $timeout,$messageCenterService) {
       return {
         mcMessages: this.mcMessages || [],
         offlistener: this.offlistener || undefined,
@@ -26,6 +43,7 @@ MessageCenterModule.
           var availableTypes = ['info', 'warning', 'danger', 'success'],
             service = this;
           options = options || {};
+          var options = angular.extend($messageCenterService.getOptions(), options);
           if (availableTypes.indexOf(type) == -1) {
             throw "Invalid message type";
           }

--- a/test/app/index4.html
+++ b/test/app/index4.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="components/angular/angular.js"></script>
+    <script src="components/angular-route/angular-route.js"></script>
+    <script src="message-center.js"></script>
+    <script>
+      angular.module('messageCenter.e2e', ['MessageCenterModule', 'ngRoute'])
+      .config(function($routeProvider,$messageCenterServiceProvider) {
+        $messageCenterServiceProvider.setGlobalOptions({
+        timeout:1000
+      });
+        $routeProvider
+          .when('/',     { templateUrl: 'home' })
+          .when('/edit', { templateUrl: 'edit' })
+      })
+
+      .controller('HomeController', function($scope, $location, messageCenterService) {
+        $scope.goIndex = function() {
+          $location.path('/');
+        };
+
+        $scope.goEditSuccess = function() {
+          messageCenterService.add('success', 'You have reached the edit page!');
+         
+        };
+      })
+    </script>
+  </head>
+
+  <body data-ng-app="messageCenter.e2e">
+    <script type="text/ng-template" id="home">
+      <article data-ng-controller="HomeController" >
+        <div mc-messages></div>
+        <h1>Home</h1>
+        <button id="goEditSuccess" data-ng-click="goEditSuccess()">Edit (success)</button>
+      </article>
+    </script>
+
+
+
+    <article data-ng-view />
+  </body>
+</html>

--- a/test/scenarios.js
+++ b/test/scenarios.js
@@ -246,3 +246,26 @@ describe('Message Center with multiple directives', function() {
     });
   });
 });
+
+
+describe('Message Center with global configurations', function() {
+
+  beforeEach(module('MessageCenterModule'));
+
+  beforeEach(function() { browser().navigateTo('/index4.html'); });
+
+  it('renders an empty ordered list on its initial state', function() {
+    expect(element('div#mc-messages-wrapper').count()).toBe(1);
+    expect(element('div#mc-messages-wrapper .alert').count()).toBe(0);
+  });
+
+  describe('when navigating through two views', function() {
+
+    it('renders a message with the default "success" level', function() {
+      element('#goEditSuccess').click();
+      var messages = element('div#mc-messages-wrapper .alert');
+      expect(messages.count()).toBe(0);
+  
+    });
+  });
+});


### PR DESCRIPTION
Anyone now can add global options through the $messageCenterServiceProvider. This resolves #26.
Example use :
<pre>
angular
  .module('frontendApp', [
    'MessageCenterModule',
  ])
  .config(function($messageCenterServiceProvider) {
    $messageCenterServiceProvider.setGlobalOptions({timeout:100})
})
</pre>